### PR TITLE
Refactor code to be a little more idiomatic

### DIFF
--- a/ditos/ditos.go
+++ b/ditos/ditos.go
@@ -2,43 +2,32 @@ package ditos
 
 import (
 	"bufio"
-	"fmt"
 	"math/rand"
 	"os"
 	"time"
 )
 
-type Message struct {
-	ResponseType string `json:"response_type"`
-	Text         string `json:"text"`
-	Username     string `json:"username"`
-	IconUrl      string `json:"icon_url"`
+func init() {
+	rand.Seed(time.Now().UnixNano())
 }
 
-var ditos []string
+type Ditos struct {
+	ditos []string
+}
 
-func GenerateRandomDito() (*Message, error) {
-
-	rand.Seed(time.Now().Unix())
-	message := ditos[rand.Intn(len(ditos))]
-
-	fmt.Println(message)
-
-	var bah = &Message{
-		ResponseType: "in_channel",
-		Text:         message,
-		Username:     "Gaucho Macho",
-		IconUrl:      "http://www.eev.com.br/sipat/imagens/imgFotos65446.jpg",
+func New() (*Ditos, error) {
+	ditos, err := readLines("ditos/ditos.txt")
+	if err != nil {
+		return nil, err
 	}
 
-	return bah, nil
+	return &Ditos{
+		ditos: ditos,
+	}, nil
 }
 
-func LoadDitos() error {
-	var err error
-	ditos, err = readLines("ditos/ditos.txt")
-
-	return err
+func (d *Ditos) Random() string {
+	return d.ditos[rand.Intn(len(d.ditos))]
 }
 
 // readLines reads a whole file into memory
@@ -46,7 +35,6 @@ func LoadDitos() error {
 func readLines(path string) ([]string, error) {
 	file, err := os.Open(path)
 	if err != nil {
-		fmt.Println("error")
 		return nil, err
 	}
 	defer file.Close()

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -1,0 +1,52 @@
+package handler
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/cpanato/ditos_gauchos/ditos"
+)
+
+const (
+	responseType = "in_channel"
+	username     = "Gaucho Macho"
+	responseIcon = "http://www.eev.com.br/sipat/imagens/imgFotos65446.jpg"
+)
+
+type Handler struct {
+	ditos *ditos.Ditos
+}
+
+func New(ditos *ditos.Ditos) *Handler {
+	return &Handler{
+		ditos: ditos,
+	}
+}
+
+type message struct {
+	ResponseType string `json:"response_type"`
+	Text         string `json:"text"`
+	Username     string `json:"username"`
+	IconUrl      string `json:"icon_url"`
+}
+
+func (h *Handler) HandleBah(res http.ResponseWriter, req *http.Request) {
+	res.Header().Set("Content-Type", "application/json")
+
+	bah := &message{
+		ResponseType: responseType,
+		Text:         h.ditos.Random(),
+		Username:     username,
+		IconUrl:      responseIcon,
+	}
+
+	if err := json.NewEncoder(res).Encode(bah); err != nil {
+		errMsg := fmt.Sprintf("failed to encode response: %v", err)
+		log.Printf("%s\n", err)
+
+		http.Error(res, fmt.Sprintf(`{"error": %s}`, errMsg), http.StatusInternalServerError)
+		return
+	}
+}

--- a/main.go
+++ b/main.go
@@ -1,39 +1,56 @@
 package main
 
 import (
-	"encoding/json"
-	"fmt"
+	"context"
 	"log"
 	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/gorilla/mux"
 
 	"github.com/cpanato/ditos_gauchos/ditos"
-	"github.com/gorilla/mux"
+	"github.com/cpanato/ditos_gauchos/handler"
+)
+
+const (
+	addr = ":8080"
 )
 
 func main() {
-	router := mux.NewRouter()
-	router.HandleFunc("/bah", handleBah).Methods("POST")
-
-	ditos.LoadDitos()
-
-	fmt.Println("Running")
-
-	http.ListenAndServe(":8080", router)
-
-}
-
-func handleBah(res http.ResponseWriter, req *http.Request) {
-	res.Header().Set("Content-Type", "application/json")
-
-	bahMessage, _ := ditos.GenerateRandomDito()
-
-	outgoingJSON, error := json.Marshal(bahMessage)
-
-	if error != nil {
-		log.Println(error.Error())
-		http.Error(res, error.Error(), http.StatusInternalServerError)
-		return
+	ditos, err := ditos.New()
+	if err != nil {
+		log.Fatalf("failed to initialize ditos: %v\n", err)
 	}
 
-	fmt.Fprint(res, string(outgoingJSON))
+	handler := handler.New(ditos)
+	router := mux.NewRouter()
+	router.HandleFunc("/bah", handler.HandleBah).Methods("POST")
+
+	srv := http.Server{
+		Addr:    addr,
+		Handler: router,
+	}
+
+	go func() {
+		log.Printf("listening on %s\n", srv.Addr)
+		if err := srv.ListenAndServe(); err != nil {
+			log.Fatalf("failed to start server: %v\n", err)
+		}
+	}()
+
+	sig := make(chan os.Signal, 1)
+	signal.Notify(sig, os.Interrupt, syscall.SIGTERM)
+	<-sig
+
+	log.Println("interrupted, shutting down")
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := srv.Shutdown(ctx); err != nil {
+		log.Fatalf("failed to gracefully shutdown: %v\n", err)
+	}
 }


### PR DESCRIPTION
This PR refactors the code to be a little more idiomatic Go code. Some highlights:

1. Uses `func init()` to make sure `math/rand` is only seeded once
2. Gets rid of global variable `ditos` in favor of a new `Ditos` type that's initialized in `main()`
3. Extracts HTTP handling code to a new `handler` package
4. Change `main()` to listen to termination signals and perform a graceful shutdown of the server

Let me know if you have any questions! 😄 